### PR TITLE
refactor: remove options from execute function

### DIFF
--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -36,7 +36,7 @@
     "scope": "js,ts",
     "prefix": "serncommand",
     "body": [
-      "const { commandModule, CommandType } = require('@sern/handler');\r\n\r\nexport default commandModule({\r\n\ttype: CommandType.$1,\r\n\tplugins: [],\r\n\tdescription: '$2',\r\n\toptions: [],\r\n\texecute: async (ctx, options) => {\r\n\t\t$3\r\n\t},\r\n});"
+      "const { commandModule, CommandType } = require('@sern/handler');\r\n\r\nexport default commandModule({\r\n\ttype: CommandType.$1,\r\n\tplugins: [],\r\n\tdescription: '$2',\r\n\toptions: [],\r\n\texecute: async (ctx) => {\r\n\t\t$3\r\n\t},\r\n});"
     ],
     "description": "Create a simple command in sern."
   },
@@ -52,7 +52,7 @@
     "scope": "js,ts",
     "prefix": "serncommandesm",
     "body": [
-      "import { commandModule, CommandType } from '@sern/handler';\r\n\r\nexport default commandModule({\r\n\ttype: CommandType.$1,\r\n\tplugins: [],\r\n\tdescription: '$2',\r\n\toptions: [],\r\n\texecute: async (ctx, options) => {\r\n\t\t$3\r\n\t},\r\n});"
+      "import { commandModule, CommandType } from '@sern/handler';\r\n\r\nexport default commandModule({\r\n\ttype: CommandType.$1,\r\n\tplugins: [],\r\n\tdescription: '$2',\r\n\toptions: [],\r\n\texecute: async (ctx) => {\r\n\t\t$3\r\n\t},\r\n});"
     ],
     "description": "Create a simple command in sern."
   }


### PR DESCRIPTION
This is to support the upcoming options method in the future.  Use context to find options for now.